### PR TITLE
タイトル名など変更

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseurl = "https://archlinuxjp.github.io/"
 languageCode = "ja-jp"
-title = "ArchLinuxJP Blog"
+title = "Arch Linux JP Blog"
 # Enable comments by entering your Disqus shortname
 disqusShortname = "archlinuxjp"
 # Enable Google Analytics by entering your tracking code

--- a/themes/hugo-icarus-theme/layouts/partials/article_first.html
+++ b/themes/hugo-icarus-theme/layouts/partials/article_first.html
@@ -4,7 +4,7 @@
 		シンプル、明解な ArchWiki
 	</h2>
 	<p>
-		ArchLinuxJP のブログにようこそ。ここでは、ArchWikiに新しく追加したい記事アイディアやその他のTipsを、誰もが手軽に共有し、または、テンプレートそのものをより新しくするためのアイディアを投稿するために、 Git ユーザーの参加を呼びかけています。参加したい人は、<a href="https://github.com/ArchLinuxJP/archlinuxjp.github.io/tree/source">GitHub</a> からプルリクエストを送ったり、コミッターを志願することができます。
+		Arch Linux JP のブログにようこそ。ここでは、ArchWikiに新しく追加したい記事アイディアやその他のTipsを、誰もが手軽に共有し、または、テンプレートそのものをより新しくするためのアイディアを投稿するために、 Git ユーザーの参加を呼びかけています。参加したい人は、<a href="https://github.com/ArchLinuxJP/archlinuxjp.github.io/tree/source">GitHub</a> からプルリクエストを送ったり、コミッターを志願することができます。
 		<br>
 		<br>
 		Arch Linux の強固なコミュニティは多様かつ助けになり、広範なスキルセットと、それによって Arch を利用していることに誇りを持っています。<a href="https://bbs.archlinuxjp.org/">フォーラム</a>や<a href="https://lists.archlinux.org/">メーリングリスト</a>を見て参加してみて下さい。<a href="https://archlinuxjp-slack.herokuapp.com/">Slack</a> で Arch ユーザーと会話することもできます (誰でも自由に参加できます)。また、Arch について知識を深めたいと考えたのであれば、<a href="https://wiki.archlinuxjp.org/">ArchWiki</a> も覗いてみましょう。

--- a/themes/hugo-icarus-theme/layouts/partials/footer.html
+++ b/themes/hugo-icarus-theme/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <footer id="footer">
   <div class="outer">
     <div id="footer-info" class="inner">
-	    &copy; {{.Now.Format "2006"}} <a href="https://github.com/archlinuxjp"><span class="icon-archlinuxjp"></span> ArchLinuxJP</a>. <br>
+	    &copy; {{.Now.Format "2006"}} <a href="https://github.com/archlinuxjp"><span class="icon-archlinuxjp"></span> Arch Linux JP</a>. <br>
       {{ with .Site.Params.copyright }}{{ . | markdownify}}{{ end }}
     </div>
   </div>


### PR DESCRIPTION
Arch Linuxの正式名称は「ArchLinux」ではなく「Arch Linux」です。
参照: https://wiki.archlinuxjp.org/index.php/Arch_%E7%94%A8%E8%AA%9E%E9%9B%86#Arch_Linux
