### PR TITLE
ブログのロゴ変更

### DIFF
--- a/themes/hugo-icarus-theme/layouts/partials/header.html
+++ b/themes/hugo-icarus-theme/layouts/partials/header.html
@@ -15,8 +15,8 @@
 				    <span class="icon-archlinuxjp"></span>
 				    <span class="icon-archlinuxjp-simple"></span>
 				    <!--<span class="site-title">{{ .Site.Title }}</span>-->
-				    <span class="site-title-arch">arch</span>
-				    <span class="site-title-linux">linux</span>
+				    <span class="site-title-arch">Arch Linux JP Blog</span>
+				    <span class="site-title-linux"></span>
 			    </a>
 		    </h1>
 	    </div>

--- a/themes/hugo-icarus-theme/static/css/font.css
+++ b/themes/hugo-icarus-theme/static/css/font.css
@@ -126,7 +126,7 @@ h1 a:hover span.icon-archlinuxjp-simple {
 a.navbar-brand span.site-title-arch {
 	position: absolute;
 	padding-left:5px;
-	font-size:35px;
+	font-size:18px;
 	color: #fff;
 	font-weight: 500;
 }

--- a/themes/hugo-icarus-theme/static/css/font.css
+++ b/themes/hugo-icarus-theme/static/css/font.css
@@ -9,7 +9,7 @@
 .navbar-brand span.icon-archlinuxjp {
 	font-size: 40px;
 	position: absolute;
-	color: #1793D1;
+	color: #444;
 }
 
 .navbar-brand span.site-title {


### PR DESCRIPTION
普通のフォントでarch linuxと青白で表示するのはとても違和感があります。
それに、ロゴをクリックすると、Arch Linux JP Project のトップページ (https://www.archlinuxjp.org/) ではなくブログのトップに飛ぶ以上、ウェブサイトの他とは違うことをちゃんとわかるようにBlogという文字をつけて色もわかりやすく変えてみました。
